### PR TITLE
ImageStreams should always come before BuildConfigs

### DIFF
--- a/kubernetes-model/src/main/java/io/fabric8/kubernetes/internal/HasMetadataComparator.java
+++ b/kubernetes-model/src/main/java/io/fabric8/kubernetes/internal/HasMetadataComparator.java
@@ -40,6 +40,8 @@ public class HasMetadataComparator implements Comparator<HasMetadata> {
                     return 5;
                 case PersistentVolumeClaim:
                     return 6;
+                case ImageStream:
+                    return 7;
                 default:
                     return 100;
             }


### PR DESCRIPTION
Processing the [EAP template](https://github.com/jboss-openshift/application-templates/blob/master/eap/eap6-basic-s2i.json|) and then creating the resources causes the s2i build to fail, because the ImageStream gets created after the BuildConfig. This messes up the image push (see https://gist.github.com/alesj/d081588c507cfafb1c46 at the bottom)

This patch fixes the problem, but IMHO, the resource list created by the processing of a template should never be sorted (it is sorted in https://github.com/fabric8io/kubernetes-model/blob/master/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/KubernetesList.java#L73 )

