### PR TITLE
Fix deserialization of extension resources

### DIFF
--- a/kubernetes-model/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -33,6 +33,7 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
     private static final String KIND = "kind";
 
     private static final String KUBERNETES_PACKAGE_PREFIX = "io.fabric8.kubernetes.api.model.";
+    private static final String KUBERNETES_EXTENSIONS_PACKAGE_PREFIX = "io.fabric8.kubernetes.api.model.extensions.";
     private static final String OPENSHIFT_PACKAGE_PREFIX = "io.fabric8.openshift.api.model.";
 
     private static final Map<String, Class<? extends KubernetesResource>> MAP = new HashMap<>();
@@ -64,7 +65,10 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
         if (result == null) {
             result = loadClassIfExists(KUBERNETES_PACKAGE_PREFIX + name);
             if (result == null) {
-                result = loadClassIfExists(OPENSHIFT_PACKAGE_PREFIX + name);
+                result = loadClassIfExists(KUBERNETES_EXTENSIONS_PACKAGE_PREFIX + name);
+                if (result == null) {
+                    result = loadClassIfExists(OPENSHIFT_PACKAGE_PREFIX + name);
+                }
             }
         }
 


### PR DESCRIPTION
Have `KubernetesDeserializer.getTypeForKind` search in the extensions
namespace for matching types.

Previously, deserializing an extension type like a `Job` would fail when
trying to watch jobs, since the `Job` type could not be found.