### PR TITLE
Force apiVersion, kind & metadata to be first in serialization for all types

### DIFF
--- a/kubernetes-model-annotator/src/main/java/io/fabric8/kubernetes/annotator/KubernetesTypeAnnotator.java
+++ b/kubernetes-model-annotator/src/main/java/io/fabric8/kubernetes/annotator/KubernetesTypeAnnotator.java
@@ -38,7 +38,6 @@ import java.util.Map;
 public class KubernetesTypeAnnotator extends Jackson2Annotator {
 
     private final String nameIsDNS952LabelPattern = "[a-z]([-a-z0-9]*[a-z0-9])?";
-    private final int nameIsDNS952LabelLength = 24;
 
     private final String nameIsDNS1123LabelPattern = "[a-z0-9]([-a-z0-9]*[a-z0-9])?";
     private final int nameIsDNS1123LabelLength = 63;
@@ -84,10 +83,7 @@ public class KubernetesTypeAnnotator extends Jackson2Annotator {
 
     private int getObjectNameMaxLength(JDefinedClass clazz) {
         String kind = clazz.name();
-        if (kind.equals("Service")) {
-            return nameIsDNS952LabelLength;
-        }
-        if (kind.equals("Namespace") || kind.equals("Project")) {
+        if (kind.equals("Namespace") || kind.equals("Project") || kind.equals("Service")) {
             return nameIsDNS1123LabelLength;
         }
         return nameIsDNS1123SubdomainLength;

--- a/kubernetes-model-annotator/src/main/java/io/fabric8/kubernetes/annotator/KubernetesTypeAnnotator.java
+++ b/kubernetes-model-annotator/src/main/java/io/fabric8/kubernetes/annotator/KubernetesTypeAnnotator.java
@@ -15,22 +15,24 @@
  */
 package io.fabric8.kubernetes.annotator;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sun.codemodel.JAnnotationArrayMember;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JClassAlreadyExistsException;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
-import com.sun.codemodel.JEnumConstant;
 import com.sun.codemodel.JFieldVar;
-import com.sun.codemodel.JMethod;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.Inline;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.jsonschema2pojo.Jackson2Annotator;
 
+import java.util.Iterator;
 import java.util.Map;
 
 public class KubernetesTypeAnnotator extends Jackson2Annotator {
@@ -46,6 +48,18 @@ public class KubernetesTypeAnnotator extends Jackson2Annotator {
 
     @Override
     public void propertyOrder(JDefinedClass clazz, JsonNode propertiesNode) {
+        JAnnotationArrayMember annotationValue = clazz.annotate(JsonPropertyOrder.class).paramArray("value");
+
+        annotationValue.param("apiVersion");
+        annotationValue.param("kind");
+        annotationValue.param("metadata");
+        for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
+            String next = properties.next();
+            if (!next.equals("apiVersion") && !next.equals("kind") && !next.equals("metadata")) {
+                annotationValue.param(next);
+            }
+        }
+
         //We just want to make sure we avoid infinite loops
         clazz.annotate(JsonDeserialize.class)
                 .param("using", JsonDeserializer.None.class);
@@ -124,58 +138,4 @@ public class KubernetesTypeAnnotator extends Jackson2Annotator {
             || kind.equals("OAuthAccessToken") || kind.equals("OAuthAuthorizeToken") || kind.equals("OAuthClientAuthorization");
     }
 
-    @Override
-    public void propertyInclusion(JDefinedClass clazz, JsonNode schema) {
-
-    }
-
-    @Override
-    public void propertyField(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
-
-    }
-
-    @Override
-    public void propertyGetter(JMethod getter, String propertyName) {
-
-    }
-
-    @Override
-    public void propertySetter(JMethod setter, String propertyName) {
-
-    }
-
-    @Override
-    public void anyGetter(JMethod getter) {
-
-    }
-
-    @Override
-    public void anySetter(JMethod setter) {
-
-    }
-
-    @Override
-    public void enumCreatorMethod(JMethod creatorMethod) {
-
-    }
-
-    @Override
-    public void enumValueMethod(JMethod valueMethod) {
-
-    }
-
-    @Override
-    public void enumConstant(JEnumConstant constant, String value) {
-
-    }
-
-    @Override
-    public boolean isAdditionalPropertiesSupported() {
-        return true;
-    }
-
-    @Override
-    public void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName) {
-
-    }
 }

--- a/kubernetes-model/pom.xml
+++ b/kubernetes-model/pom.xml
@@ -93,6 +93,7 @@
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
           <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
           <customAnnotator>io.fabric8.kubernetes.annotator.KubernetesTypeAnnotator</customAnnotator>
+          <annotationStyle>none</annotationStyle>
         </configuration>
         <executions>
           <execution>

--- a/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/KubernetesList.java
+++ b/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/KubernetesList.java
@@ -36,18 +36,10 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({
-        "annotations",
         "apiVersion",
-        "creationTimestamp",
-        "deletionTimestamp",
-        "generateName",
-        "id",
-        "items",
         "kind",
-        "namespace",
-        "resourceVersion",
-        "selfLink",
-        "uid"
+        "metadata",
+        "items",
 })
 @JsonDeserialize(using = JsonDeserializer.None.class)
 @Buildable(editableEnabled = false, validationEnabled = true, generateBuilderPackage=true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))

--- a/kubernetes-model/src/main/java/io/fabric8/openshift/api/model/Template.java
+++ b/kubernetes-model/src/main/java/io/fabric8/openshift/api/model/Template.java
@@ -52,8 +52,8 @@ import java.util.Map;
 @JsonPropertyOrder({
         "apiVersion",
         "kind",
-        "labels",
         "metadata",
+        "labels",
         "objects",
         "parameters"
 })


### PR DESCRIPTION
Fixes #155

@jstrachan If you want to do stuff for #154 just edit KubernetesTypeAnnotator appropriately. This will also need a release obviously