### PR TITLE
Added PetSets to the model generator, and the kubernetes schema

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -34,6 +34,7 @@ import (
 	routeapi "github.com/openshift/origin/pkg/route/api/v1"
 	templateapi "github.com/openshift/origin/pkg/template/api/v1"
 	userapi "github.com/openshift/origin/pkg/user/api/v1"
+	appsapi "k8s.io/kubernetes/pkg/apis/apps/v1alpha1"
 	resourceapi "k8s.io/kubernetes/pkg/api/resource"
 	rapi "k8s.io/kubernetes/pkg/api/unversioned"
 	kapi "k8s.io/kubernetes/pkg/api/v1"
@@ -139,6 +140,8 @@ type Schema struct {
 	Deployment                     extensions.Deployment
 	DeploymentList                 extensions.DeploymentList
 	DeploymentRollback             extensions.DeploymentRollback
+	PetSet                         appsapi.PetSet
+	PetSetList                     appsapi.PetSetList
 	DaemonSet                      extensions.DaemonSet
 	DaemonSetList                  extensions.DaemonSetList
 	Ingress                        extensions.Ingress
@@ -173,6 +176,7 @@ func main() {
 		{"k8s.io/kubernetes/pkg/api/unversioned", "io.fabric8.kubernetes.api.model", "api_"},
 		{"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/v1", "io.fabric8.kubernetes.api.model", "clientcmd_api_"},
 		{"k8s.io/kubernetes/pkg/apis/extensions/v1beta1", "io.fabric8.kubernetes.api.model.extensions", "kubernetes_extensions_"},
+		{"k8s.io/kubernetes/pkg/apis/apps/v1alpha1", "io.fabric8.kubernetes.api.model.extensions", "kubernetes_apps_"},
 	}
 
 	typeMap := map[reflect.Type]reflect.Type{

--- a/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -5080,6 +5080,132 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apps_PetSet": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "apps/v1alpha1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PetSet",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/kubernetes_apps_PetSetSpec",
+          "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSetSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/kubernetes_apps_PetSetStatus",
+          "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSetStatus"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSet",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_apps_PetSetList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "apps/v1alpha1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apps_PetSet",
+            "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSet"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PetSetList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/api_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSetList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList"
+      ]
+    },
+    "kubernetes_apps_PetSetSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "description": ""
+        },
+        "selector": {
+          "$ref": "#/definitions/api_LabelSelector",
+          "javaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        },
+        "serviceName": {
+          "type": "string",
+          "description": ""
+        },
+        "template": {
+          "$ref": "#/definitions/kubernetes_PodTemplateSpec",
+          "javaType": "io.fabric8.kubernetes.api.model.PodTemplateSpec"
+        },
+        "volumeClaimTemplates": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_PersistentVolumeClaim",
+            "javaType": "io.fabric8.kubernetes.api.model.PersistentVolumeClaim"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSetSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_apps_PetSetStatus": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "observedGeneration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "replicas": {
+          "type": "integer",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSetStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_extensions_APIVersion": {
       "type": "object",
       "description": "",
@@ -9709,20 +9835,20 @@
       "type": "object",
       "description": "",
       "properties": {
-        "created": {
+        "Created": {
           "type": "string",
           "description": ""
         },
-        "dockerImageReference": {
+        "DockerImageReference": {
           "type": "string",
           "description": ""
         },
-        "generation": {
+        "Generation": {
           "type": "integer",
           "description": "",
           "javaType": "Long"
         },
-        "image": {
+        "Image": {
           "type": "string",
           "description": ""
         }
@@ -11280,6 +11406,14 @@
     "PersistentVolumeList": {
       "$ref": "#/definitions/kubernetes_PersistentVolumeList",
       "javaType": "io.fabric8.kubernetes.api.model.PersistentVolumeList"
+    },
+    "PetSet": {
+      "$ref": "#/definitions/kubernetes_apps_PetSet",
+      "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSet"
+    },
+    "PetSetList": {
+      "$ref": "#/definitions/kubernetes_apps_PetSetList",
+      "javaType": "io.fabric8.kubernetes.api.model.extensions.PetSetList"
     },
     "PodList": {
       "$ref": "#/definitions/kubernetes_PodList",


### PR DESCRIPTION
This didn't require much work at all. All I had to do was pull down the sources (on a Linux machine) and make a minor set of modifications to generate.go to pick up the apps/v1alpha1 schema which contains the PetSet definition. 