### PR TITLE
Remove non-public API DockerImage

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -27,8 +27,7 @@ import (
 	authapi "github.com/openshift/origin/pkg/authorization/api/v1"
 	buildapi "github.com/openshift/origin/pkg/build/api/v1"
 	deployapi "github.com/openshift/origin/pkg/deploy/api/v1"
-	imageapi "github.com/openshift/origin/pkg/image/api"
-	imageapiv1 "github.com/openshift/origin/pkg/image/api/v1"
+	imageapi "github.com/openshift/origin/pkg/image/api/v1"
 	oauthapi "github.com/openshift/origin/pkg/oauth/api/v1"
 	projectapi "github.com/openshift/origin/pkg/project/api/v1"
 	routeapi "github.com/openshift/origin/pkg/route/api/v1"
@@ -81,10 +80,9 @@ type Schema struct {
 	BuildRequest                   buildapi.BuildRequest
 	BuildList                      buildapi.BuildList
 	BuildConfigList                buildapi.BuildConfigList
-	ImageList                      imageapiv1.ImageList
-	ImageStreamList                imageapiv1.ImageStreamList
-	ImageStreamTagList             imageapiv1.ImageStreamTagList
-	DockerImage                    imageapi.DockerImage
+	ImageList                      imageapi.ImageList
+	ImageStreamList                imageapi.ImageStreamList
+	ImageStreamTagList             imageapi.ImageStreamTagList
 	DeploymentConfigList           deployapi.DeploymentConfigList
 	RouteList                      routeapi.RouteList
 	ComponentStatusList            kapi.ComponentStatusList

--- a/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -9067,239 +9067,6 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
-    "os_image_DockerConfig": {
-      "type": "object",
-      "description": "",
-      "properties": {
-        "AttachStderr": {
-          "type": "boolean",
-          "description": ""
-        },
-        "AttachStdin": {
-          "type": "boolean",
-          "description": ""
-        },
-        "AttachStdout": {
-          "type": "boolean",
-          "description": ""
-        },
-        "Cmd": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "CpuShares": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
-        },
-        "Cpuset": {
-          "type": "string",
-          "description": ""
-        },
-        "Dns": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "Domainname": {
-          "type": "string",
-          "description": ""
-        },
-        "Entrypoint": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "Env": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "ExposedPorts": {
-          "type": "object",
-          "description": "",
-          "additionalProperties": {
-            "type": "string",
-            "description": ""
-          },
-          "javaType": "java.util.Map\u003cString,Object\u003e"
-        },
-        "Hostname": {
-          "type": "string",
-          "description": ""
-        },
-        "Image": {
-          "type": "string",
-          "description": ""
-        },
-        "Labels": {
-          "type": "object",
-          "description": "",
-          "additionalProperties": {
-            "type": "string",
-            "description": ""
-          },
-          "javaType": "java.util.Map\u003cString,String\u003e"
-        },
-        "Memory": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
-        },
-        "MemorySwap": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
-        },
-        "NetworkDisabled": {
-          "type": "boolean",
-          "description": ""
-        },
-        "OnBuild": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "OpenStdin": {
-          "type": "boolean",
-          "description": ""
-        },
-        "PortSpecs": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "SecurityOpts": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
-        },
-        "StdinOnce": {
-          "type": "boolean",
-          "description": ""
-        },
-        "Tty": {
-          "type": "boolean",
-          "description": ""
-        },
-        "User": {
-          "type": "string",
-          "description": ""
-        },
-        "Volumes": {
-          "type": "object",
-          "description": "",
-          "additionalProperties": {
-            "type": "string",
-            "description": ""
-          },
-          "javaType": "java.util.Map\u003cString,Object\u003e"
-        },
-        "VolumesFrom": {
-          "type": "string",
-          "description": ""
-        },
-        "WorkingDir": {
-          "type": "string",
-          "description": ""
-        }
-      },
-      "additionalProperties": true,
-      "javaType": "io.fabric8.openshift.api.model.DockerConfig",
-      "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.KubernetesResource"
-      ]
-    },
-    "os_image_DockerImage": {
-      "type": "object",
-      "description": "",
-      "properties": {
-        "Architecture": {
-          "type": "string",
-          "description": ""
-        },
-        "Author": {
-          "type": "string",
-          "description": ""
-        },
-        "Comment": {
-          "type": "string",
-          "description": ""
-        },
-        "Config": {
-          "$ref": "#/definitions/os_image_DockerConfig",
-          "javaType": "io.fabric8.openshift.api.model.DockerConfig"
-        },
-        "Container": {
-          "type": "string",
-          "description": ""
-        },
-        "ContainerConfig": {
-          "$ref": "#/definitions/os_image_DockerConfig",
-          "javaType": "io.fabric8.openshift.api.model.DockerConfig"
-        },
-        "Created": {
-          "type": "string",
-          "description": ""
-        },
-        "DockerVersion": {
-          "type": "string",
-          "description": ""
-        },
-        "Id": {
-          "type": "string",
-          "description": ""
-        },
-        "Parent": {
-          "type": "string",
-          "description": ""
-        },
-        "Size": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
-        },
-        "apiVersion": {
-          "type": "string",
-          "description": "",
-          "default": "image/api",
-          "required": true
-        },
-        "kind": {
-          "type": "string",
-          "description": "",
-          "default": "DockerImage",
-          "required": true
-        }
-      },
-      "additionalProperties": true,
-      "javaType": "io.fabric8.openshift.api.model.DockerImage",
-      "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.KubernetesResource"
-      ]
-    },
     "os_image_Image": {
       "type": "object",
       "description": "",
@@ -9835,20 +9602,20 @@
       "type": "object",
       "description": "",
       "properties": {
-        "Created": {
+        "created": {
           "type": "string",
           "description": ""
         },
-        "DockerImageReference": {
+        "dockerImageReference": {
           "type": "string",
           "description": ""
         },
-        "Generation": {
+        "generation": {
           "type": "integer",
           "description": "",
           "javaType": "Long"
         },
-        "Image": {
+        "image": {
           "type": "string",
           "description": ""
         }
@@ -11250,10 +11017,6 @@
     "DeploymentRollback": {
       "$ref": "#/definitions/kubernetes_extensions_DeploymentRollback",
       "javaType": "io.fabric8.kubernetes.api.model.extensions.DeploymentRollback"
-    },
-    "DockerImage": {
-      "$ref": "#/definitions/os_image_DockerImage",
-      "javaType": "io.fabric8.openshift.api.model.DockerImage"
     },
     "Endpoints": {
       "$ref": "#/definitions/kubernetes_Endpoints",

--- a/pkg/schemagen/generate.go
+++ b/pkg/schemagen/generate.go
@@ -322,6 +322,11 @@ func (g *schemaGenerator) getStructProperties(t reflect.Type) map[string]JSONPro
 		if name == "-" {
 			continue
 		}
+		// Skip dockerImageMetadata field
+		if t.PkgPath() == "github.com/openshift/origin/pkg/image/api/v1" && t.Name() == "Image" && name == "dockerImageMetadata" {
+			continue
+		}
+
 		desc := getFieldDescription(field)
 		prop := g.getPropertyDescriptor(field.Type, desc)
 		if field.Anonymous && field.Type.Kind() == reflect.Struct && len(name) == 0 {


### PR DESCRIPTION
This removes DockerImage as it's not part of the public API. If the fields are
required they will be accessible via additionalProperties.

This also corrects the JSON field names for ImageStreamTag

@iocanel Could you take a look please?