### PR TITLE
Add a CI pipeline that works with fabric8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ def dummy
 mavenNode {
   ws{
     checkout scm
+    readTrusted 'release.groovy'
     sh "git remote set-url origin git@github.com:fabric8io/kubernetes-model.git"
 
     def pipeline = load 'release.groovy'


### PR DESCRIPTION
The existing ci.fabric8.io infra seems to be having problems lately.  This PR adds a CI pipeline to the Jenkinsfile which means we can run CI on our jenkins.cd.k8s.fabric8.io instance.  

The benefits include:
  - dogfooding our CI solution
  - having our CI configuration in source control (and all the goodness of pipeline as code)

Downside:
  - the github pull request builder and Jenkins pipelines don't work together, which means `ok to test` and `merge` comments cannot be used to controller PR jobs.  
  - this is one of the first Jenkinsfile CI enabled fabric8 projects so we are still learning what works best, so there will probably be some improvements needed as we do more.