### PR TITLE
fix(api): add a setApiVersion() method

### DIFF
--- a/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
+++ b/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
@@ -23,4 +23,5 @@ public interface HasMetadata extends KubernetesResource {
   String getKind();
 
   String getApiVersion();
+  void setApiVersion(String version);
 }


### PR DESCRIPTION
lets add a setApiVersion() method to `HasMetadata` for times when tools (like kubernetes-client) wants to default the value
e.g. when loading an API Groups based `list()` of values which have a blank `apiVersion` in each item; we can use this API to
override the default if the version is not `v1`