### PR TITLE
Updated apiVersion for SecurityContextConstraints

### DIFF
--- a/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -13177,7 +13177,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "security.openshift.io/v1",
+          "default": "v1",
           "required": true
         },
         "defaultAddCapabilities": {
@@ -13276,7 +13276,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "security.openshift.io/v1",
+          "default": "v1",
           "required": true
         },
         "items": {

--- a/pkg/schemagen/generate.go
+++ b/pkg/schemagen/generate.go
@@ -382,7 +382,9 @@ func (g *schemaGenerator) getStructProperties(t reflect.Type) map[string]JSONPro
 						if strings.HasPrefix(path, "github.com/openshift/origin/pkg/") {
 							groupPostfix = ".openshift.io"
 						}
-						apiVersion = apiGroup + groupPostfix + "/" + apiVersion
+						if t.Name() != "SecurityContextConstraints" && t.Name() != "SecurityContextConstraintsList" {
+						    apiVersion = apiGroup + groupPostfix + "/" + apiVersion
+						}
 					}
 					v = JSONPropertyDescriptor{
 						JSONDescriptor: &JSONDescriptor{

--- a/pkg/schemagen/generate.go
+++ b/pkg/schemagen/generate.go
@@ -382,6 +382,11 @@ func (g *schemaGenerator) getStructProperties(t reflect.Type) map[string]JSONPro
 						if strings.HasPrefix(path, "github.com/openshift/origin/pkg/") {
 							groupPostfix = ".openshift.io"
 						}
+
+						//Added a special case for SecurityContextConstraints and SecurityContextConstraintsList
+						//Because its fetching "security.openshift.io/v1"
+						//and "v1" is working with kubernetes-client
+						 
 						if t.Name() != "SecurityContextConstraints" && t.Name() != "SecurityContextConstraintsList" {
 						    apiVersion = apiGroup + groupPostfix + "/" + apiVersion
 						}


### PR DESCRIPTION
Added a case while generating SecurityContextConstraints
to set the default apiVersion to v1

This will also fix the SecurityContextConstraints problem in Kubernetes Client
[#962](https://github.com/fabric8io/kubernetes-client/issues/962)