### PR TITLE
Fixes ImageStreamTag Marshal Error

### DIFF
--- a/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -629,6 +629,21 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "k8s_io_apimachinery_pkg_runtime_ImageRawExtension": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "Raw": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.runtime.RawExtension",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "k8s_io_apimachinery_pkg_runtime_RawExtension": {
       "type": "object",
       "description": "",
@@ -1401,7 +1416,9 @@
         },
         "name": {
           "type": "string",
-          "description": ""
+          "description": "",
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
         },
         "protocol": {
           "type": "string",
@@ -12102,8 +12119,8 @@
           "description": ""
         },
         "dockerImageMetadata": {
-          "$ref": "#/definitions/k8s_io_apimachinery_pkg_runtime_RawExtension",
-          "javaType": "io.fabric8.kubernetes.api.model.HasMetadata"
+          "$ref": "#/definitions/k8s_io_apimachinery_pkg_runtime_ImageRawExtension",
+          "javaType": "io.fabric8.kubernetes.api.model.runtime.RawExtension"
         },
         "dockerImageMetadataVersion": {
           "type": "string",

--- a/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/ImageStreamTagTest.java
+++ b/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/ImageStreamTagTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.ImageBuilder;
+import io.fabric8.openshift.api.model.ImageLayerBuilder;
+import io.fabric8.openshift.api.model.ImageLookupPolicyBuilder;
+import io.fabric8.openshift.api.model.ImageStreamTagBuilder;
+import io.fabric8.openshift.api.model.TagReferenceBuilder;
+import org.junit.Test;
+
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class ImageStreamTagTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void imageStreamTagTest() throws Exception {
+        // given
+        final String originalJson = Helper.loadJson("/valid-ist.json");
+
+        // when
+        final ImageStreamTag ist = mapper.readValue(originalJson, ImageStreamTag.class);
+        final String serializedJson = mapper.writeValueAsString(ist);
+
+        // then
+        assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+                .isEqualTo(originalJson);
+    }
+
+    @Test
+    public void imageStreamTagBuilderTest() {
+
+        ImageStreamTag ist = new ImageStreamTagBuilder()
+                .withNewMetadata()
+                        .withName("bar1:1.0.12")
+                        .withNamespace("myproject")
+                        .withCreationTimestamp("2018-04-12T09:22:41Z")
+                        .withResourceVersion("1523")
+                        .withSelfLink("/oapi/v1/namespaces/myproject/imagestreamtags/bar1%3A1.0.12")
+                .endMetadata()
+                .withLookupPolicy(new ImageLookupPolicyBuilder()
+                        .withLocal(false)
+                        .build()
+                )
+                .withGeneration(2L)
+                .withImage(new ImageBuilder()
+                        .addToDockerImageLayers(0, new ImageLayerBuilder()
+                                .withMediaType("application/vnd.docker.image.rootfs.diff.tar.gzip")
+                                .withName("sha256:8111c19639475fb11ffa928f9e5e2dc05cbbe143363889355d2fee66a9f5664c")
+                                .withSize(1160L)
+                                .build()
+                        )
+                        .withDockerImageReference("docker.io/openshift/jenkins-slave-maven-centos7@sha256:df7bb31ff8f3ae0918b2e8b5c29b3deed04c547142abbc49ad133e9451ebb660")
+                        .withDockerImageMetadataVersion("1.0")
+                        .withNewMetadata()
+                            .withName("sha256:df7bb31ff8f3ae0918b2e8b5c29b3deed04c547142abbc49ad133e9451ebb660")
+                            .withCreationTimestamp("2018-04-12T09:22:41Z")
+                        .endMetadata()
+                        .build()
+                )
+                .withTag(new TagReferenceBuilder()
+                        .withName("1.0.12")
+                        .withFrom(new io.fabric8.kubernetes.api.model.ObjectReferenceBuilder()
+                                .withKind("DockerImage")
+                                .withName("docker.io/openshift/jenkins-slave-maven-centos7:latest")
+                                .build()
+                        )
+                        .withGeneration(2L)
+                        .addToAnnotations("role", "jenkins-slave")
+                        .addToAnnotations("slave-label", "jenkins-slave")
+                        .withReferencePolicy(new io.fabric8.openshift.api.model.TagReferencePolicyBuilder()
+                                .withType("Source")
+                                .build()
+                        )
+                        .build()
+                ).build();
+
+        assertNotNull(ist);
+        assertEquals("bar1:1.0.12", ist.getMetadata().getName());
+        assertEquals("myproject", ist.getMetadata().getNamespace());
+        assertEquals("1523", ist.getMetadata().getResourceVersion());
+        assertEquals("2018-04-12T09:22:41Z", ist.getMetadata().getCreationTimestamp());
+        assertEquals("/oapi/v1/namespaces/myproject/imagestreamtags/bar1%3A1.0.12", ist.getMetadata()
+                .getSelfLink());
+        assertFalse(ist.getLookupPolicy().getLocal());
+        assertEquals(2L, ist.getGeneration().intValue());
+        assertEquals(1, ist.getImage().getDockerImageLayers().size());
+        assertEquals("application/vnd.docker.image.rootfs.diff.tar.gzip", ist.getImage()
+                .getDockerImageLayers().get(0).getMediaType());
+        assertEquals("sha256:8111c19639475fb11ffa928f9e5e2dc05cbbe143363889355d2fee66a9f5664c", ist.
+                getImage().getDockerImageLayers().get(0).getName());
+        assertEquals(1160L, ist.getImage().getDockerImageLayers().get(0).getSize().intValue());
+        assertEquals("docker.io/openshift/jenkins-slave-maven-centos7@sha256:df7bb31ff8f3ae0918b2e8b5c29b3deed04c547142abbc49ad133e9451ebb660", ist.
+                getImage().getDockerImageReference());
+        assertEquals("1.0", ist.getImage().getDockerImageMetadataVersion());
+        assertEquals("sha256:df7bb31ff8f3ae0918b2e8b5c29b3deed04c547142abbc49ad133e9451ebb660", ist.
+                getImage().getMetadata().getName());
+        assertEquals("2018-04-12T09:22:41Z", ist.getImage().getMetadata().getCreationTimestamp());
+        assertEquals("1.0.12", ist.getTag().getName());
+        assertEquals("DockerImage", ist.getTag().getFrom().getKind());
+        assertEquals("docker.io/openshift/jenkins-slave-maven-centos7:latest", ist.getTag().getFrom().getName());
+        assertEquals(2L, ist.getTag().getGeneration().intValue());
+        assertEquals("jenkins-slave", ist.getTag().getAnnotations().get("role"));
+        assertEquals("jenkins-slave", ist.getTag().getAnnotations().get("slave-label"));
+        assertEquals("Source", ist.getTag().getReferencePolicy().getType());
+
+    }
+
+}

--- a/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/RouteTest.java
+++ b/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/RouteTest.java
@@ -18,7 +18,6 @@ package io.fabric8.kubernetes.api.model;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
-import io.fabric8.openshift.api.model.RouteTargetReference;
 import io.fabric8.openshift.api.model.RouteTargetReferenceBuilder;
 import org.junit.Test;
 

--- a/kubernetes-model/src/test/resources/valid-ist.json
+++ b/kubernetes-model/src/test/resources/valid-ist.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "v1",
+  "generation": 2,
+  "image": {
+    "dockerImageLayers": [
+      {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "name": "sha256:8111c19639475fb11ffa928f9e5e2dc05cbbe143363889355d2fee66a9f5664c",
+        "size": 1160
+      }
+    ],
+    "dockerImageMetadata": {
+      "ContainerConfig": {},
+      "Created": null,
+      "Id": "",
+      "apiVersion": "1.0",
+      "kind": "DockerImage"
+    },
+    "dockerImageMetadataVersion": "1.0",
+    "dockerImageReference": "docker.io/openshift/jenkins-slave-maven-centos7@sha256:df7bb31ff8f3ae0918b2e8b5c29b3deed04c547142abbc49ad133e9451ebb660",
+    "metadata": {
+      "creationTimestamp": "2018-04-12T09:22:41Z",
+      "name": "sha256:df7bb31ff8f3ae0918b2e8b5c29b3deed04c547142abbc49ad133e9451ebb660"
+    }
+  },
+  "kind": "ImageStreamTag",
+  "lookupPolicy": {
+    "local": false
+  },
+  "metadata": {
+    "creationTimestamp": "2018-04-12T09:22:41Z",
+    "name": "bar1:1.0.12",
+    "namespace": "myproject",
+    "resourceVersion": "1523",
+    "selfLink": "/oapi/v1/namespaces/myproject/imagestreamtags/bar1%3A1.0.12"
+  },
+  "tag": {
+    "annotations": {
+      "role": "jenkins-slave",
+      "slave-label": "jenkins-slave"
+    },
+    "from": {
+      "kind": "DockerImage",
+      "name": "docker.io/openshift/jenkins-slave-maven-centos7:latest"
+    },
+    "generation": 2,
+    "importPolicy": {},
+    "name": "1.0.12",
+    "referencePolicy": {
+      "type": "Source"
+    }
+  }
+}


### PR DESCRIPTION
Added a specific class for DockerImageMetadata because its kind of RawExtension and is set to HasMetadata Java Type. Because of this thing it's not getting marshaled and throwing an error. We need to change it to RawExtension but to change it to Raw Extension we need to create a special class for DockerMetadata Only. Reason is all the RawExtension Object are set to HasMetadata Java Type and if we change all the objects to RawExtension then classes like KubernetesList etc. are throwing error If we change the class of DockerMetadata only then also it will get generated of kind HasMetadata because RawExtension Object is also set to HasMetadata Jaya Type If we further change RawExtension Object to RawExtension Java Type then again all KubernetesList like object throw error so created a special Class ImageRawExtension for DockerImageData which will be of Raw Extension Java Type and the problem of marshalling get Resolved. This will be applied to DockerMetadata only and all the other.

Also fixed a typo in name ContainerPort

#296