### PR TITLE
Add support for ClusterRole and ClusterRoleBinding from the Kubernetes RBAC API

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -198,6 +198,10 @@ type Schema struct {
 	K8sRoleBindingList           rbac.RoleBindingList
 	NetNameSpace                 networkapi.NetNamespace
 	NetNameSpaceList             networkapi.NetNamespaceList
+	K8sClusterRole               rbac.ClusterRole
+	K8sClusterRoleList           rbac.ClusterRoleList
+	K8sClusterRoleBinding        rbac.ClusterRoleBinding
+	K8sClusterRoleBindingList    rbac.ClusterRoleBindingList
 }
 
 func main() {

--- a/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -9963,6 +9963,156 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_rbac_ClusterRole": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "aggregationRule": {
+          "$ref": "#/definitions/kubernetes_rbac_AggregationRule",
+          "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesAggregationRule"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRole",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "rules": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesPolicyRule"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_rbac_ClusterRoleBinding": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleBinding",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "roleRef": {
+          "$ref": "#/definitions/kubernetes_rbac_RoleRef",
+          "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRef"
+        },
+        "subjects": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_Subject",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesSubject"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_rbac_ClusterRoleBindingList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleBindingList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList"
+      ]
+    },
+    "kubernetes_rbac_ClusterRoleList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRole",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList"
+      ]
+    },
     "kubernetes_rbac_PolicyRule": {
       "type": "object",
       "description": "",
@@ -16014,6 +16164,22 @@
     "JobList": {
       "$ref": "#/definitions/kubernetes_batch_JobList",
       "javaType": "io.fabric8.kubernetes.api.model.batch.JobList"
+    },
+    "K8sClusterRole": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRole",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole"
+    },
+    "K8sClusterRoleBinding": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding"
+    },
+    "K8sClusterRoleBindingList": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBindingList",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList"
+    },
+    "K8sClusterRoleList": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRoleList",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList"
     },
     "K8sLocalSubjectAccessReview": {
       "$ref": "#/definitions/kubernetes_authorization_LocalSubjectAccessReview",

--- a/kubernetes-model/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model/src/main/resources/schema/validation-schema.json
@@ -9963,6 +9963,156 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_rbac_ClusterRole": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "aggregationRule": {
+          "$ref": "#/definitions/kubernetes_rbac_AggregationRule",
+          "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesAggregationRule"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRole",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "rules": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesPolicyRule"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_rbac_ClusterRoleBinding": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleBinding",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "roleRef": {
+          "$ref": "#/definitions/kubernetes_rbac_RoleRef",
+          "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRef"
+        },
+        "subjects": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_Subject",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesSubject"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_rbac_ClusterRoleBindingList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleBindingList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList"
+      ]
+    },
+    "kubernetes_rbac_ClusterRoleList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRole",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList"
+      ]
+    },
     "kubernetes_rbac_PolicyRule": {
       "type": "object",
       "description": "",
@@ -16015,6 +16165,22 @@
       "$ref": "#/definitions/kubernetes_batch_JobList",
       "javaType": "io.fabric8.kubernetes.api.model.batch.JobList"
     },
+    "K8sClusterRole": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRole",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole"
+    },
+    "K8sClusterRoleBinding": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding"
+    },
+    "K8sClusterRoleBindingList": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBindingList",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList"
+    },
+    "K8sClusterRoleList": {
+      "$ref": "#/definitions/kubernetes_rbac_ClusterRoleList",
+      "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList"
+    },
     "K8sLocalSubjectAccessReview": {
       "$ref": "#/definitions/kubernetes_authorization_LocalSubjectAccessReview",
       "javaType": "io.fabric8.kubernetes.api.model.authorization.LocalSubjectAccessReview"
@@ -17560,16 +17726,8 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
-        },
-        "groupNames": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
-          }
         },
         "kind": {
           "type": "string",
@@ -17582,23 +17740,15 @@
           "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "roleRef": {
-          "$ref": "#/definitions/kubernetes_core_ObjectReference",
-          "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
+          "$ref": "#/definitions/kubernetes_rbac_RoleRef",
+          "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRef"
         },
         "subjects": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/kubernetes_core_ObjectReference",
-            "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
-          }
-        },
-        "userNames": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "type": "string",
-            "description": ""
+            "$ref": "#/definitions/kubernetes_rbac_Subject",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesSubject"
           }
         }
       },
@@ -17609,21 +17759,50 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_ClusterRoleBinding",
-            "javaType": "io.fabric8.openshift.api.model.ClusterRoleBinding"
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding"
           }
         },
         "kind": {
           "type": "string",
           "description": "",
           "default": "ClusterRoleBindingList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true
+    },
+    "clusterrolelist": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "rbac.authorization.k8s.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRole",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterRoleList",
           "required": true
         },
         "metadata": {
@@ -19288,9 +19467,44 @@
     },
     "deploymentstrategy": {
       "properties": {
-        "rollingUpdate": {
-          "$ref": "#/definitions/kubernetes_apps_RollingUpdateDeployment",
-          "javaType": "io.fabric8.kubernetes.api.model.apps.RollingUpdateDeployment"
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "type": "string",
+            "description": ""
+          },
+          "javaType": "java.util.Map\u003cString,String\u003e"
+        },
+        "customParams": {
+          "$ref": "#/definitions/os_deploy_CustomDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.CustomDeploymentStrategyParams"
+        },
+        "labels": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "type": "string",
+            "description": ""
+          },
+          "javaType": "java.util.Map\u003cString,String\u003e"
+        },
+        "recreateParams": {
+          "$ref": "#/definitions/os_deploy_RecreateDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.RecreateDeploymentStrategyParams"
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
+          "javaType": "io.fabric8.kubernetes.api.model.ResourceRequirements"
+        },
+        "rollingParams": {
+          "$ref": "#/definitions/os_deploy_RollingDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.RollingDeploymentStrategyParams"
         },
         "type": {
           "type": "string",
@@ -19938,11 +20152,11 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_extensions_IDRange",
-            "javaType": "io.fabric8.kubernetes.api.model.extensions.IDRange"
+            "$ref": "#/definitions/os_security_IDRange",
+            "javaType": "io.fabric8.openshift.api.model.IDRange"
           }
         },
-        "rule": {
+        "type": {
           "type": "string",
           "description": ""
         }
@@ -25769,7 +25983,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -25786,8 +26000,8 @@
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_PolicyRule",
-            "javaType": "io.fabric8.openshift.api.model.PolicyRule"
+            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.KubernetesPolicyRule"
           }
         }
       },
@@ -27904,11 +28118,11 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_extensions_IDRange",
-            "javaType": "io.fabric8.kubernetes.api.model.extensions.IDRange"
+            "$ref": "#/definitions/os_security_IDRange",
+            "javaType": "io.fabric8.openshift.api.model.IDRange"
           }
         },
-        "rule": {
+        "type": {
           "type": "string",
           "description": ""
         }

--- a/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/KubernetesClusterRoleBindingTest.java
+++ b/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/KubernetesClusterRoleBindingTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
+
+import org.junit.Test;
+
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+public class KubernetesClusterRoleBindingTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void kubernetesClusterRoleBindingTest() throws Exception {
+        // given
+        final String originalJson = Helper.loadJson("/valid-kubernetesClusterRoleBinding.json");
+
+        // when
+        final KubernetesClusterRoleBinding kubernetesClusterRoleBinding = mapper.readValue(originalJson, KubernetesClusterRoleBinding.class);
+        final String serializedJson = mapper.writeValueAsString(kubernetesClusterRoleBinding);
+
+        // then
+        assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+                .isEqualTo(originalJson);
+    }
+
+    @Test
+    public void kubernetesClusterRoleBindingBuilderTest() throws Exception {
+
+        // given
+        final String originalJson = Helper.loadJson("/valid-kubernetesClusterRoleBinding.json");
+
+        // when
+        KubernetesClusterRoleBinding kubernetesClusterRoleBinding = new KubernetesClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName("read-nodes")
+                    .withNamespace("default")
+                .endMetadata()
+                .addToSubjects(0, new KubernetesSubjectBuilder()
+                        .withApiGroup("rbac.authorization.k8s.io")
+                        .withKind("ServiceAccount")
+                        .withName("node-reader")
+                        .withNamespace("default")
+                        .build()
+                )
+                .withRoleRef(new KubernetesRoleRefBuilder()
+                        .withApiGroup("rbac.authorization.k8s.io")
+                        .withKind("ClusterRole")
+                        .withName("node-reader")
+                        .build()
+                )
+                .build();
+
+        final String serializedJson = mapper.writeValueAsString(kubernetesClusterRoleBinding);
+
+        // then
+        assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+                 .isEqualTo(originalJson);
+
+    }
+}

--- a/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/KubernetesClusterRoleBindingTest.java
+++ b/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/KubernetesClusterRoleBindingTest.java
@@ -18,8 +18,6 @@ package io.fabric8.kubernetes.api.model;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
-import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBinding;
-import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
 

--- a/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/KubernetesClusterRoleTest.java
+++ b/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/KubernetesClusterRoleTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesPolicyRuleBuilder;
+
+import org.junit.Test;
+
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+public class KubernetesClusterRoleTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void kubernetesClusterRoleTest() throws Exception {
+        // given
+        final String originalJson = Helper.loadJson("/valid-kubernetesClusterRole.json");
+
+        // when
+        final KubernetesClusterRole kubernetesClusterRole = mapper.readValue(originalJson, KubernetesClusterRole.class);
+        final String serializedJson = mapper.writeValueAsString(kubernetesClusterRole);
+
+        // then
+        assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+                .isEqualTo(originalJson);
+    }
+
+    @Test
+    public void kubernetesClusterRoleBuilderTest() throws Exception {
+
+        // given
+        final String originalJson = Helper.loadJson("/valid-kubernetesClusterRole.json");
+
+        // when
+        KubernetesClusterRole kubernetesClusterRole = new KubernetesClusterRoleBuilder()
+                .withNewMetadata()
+                    .withName("node-reader")
+                .endMetadata()
+                .addToRules(0, new KubernetesPolicyRuleBuilder()
+                        .addToApiGroups(0,"")
+                        .addToNonResourceURLs(0,"/healthz")
+                        .addToResourceNames(0,"my-node")
+                        .addToResources(0,"nodes")
+                        .addToVerbs(0, "get")
+                        .addToVerbs(1, "watch")
+                        .addToVerbs(2, "list")
+                        .build()
+                    )
+                .build();
+
+        final String serializedJson = mapper.writeValueAsString(kubernetesClusterRole);
+
+        // then
+        assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+                .isEqualTo(originalJson);
+
+    }
+}

--- a/kubernetes-model/src/test/resources/valid-kubernetesClusterRole.json
+++ b/kubernetes-model/src/test/resources/valid-kubernetesClusterRole.json
@@ -1,0 +1,28 @@
+{
+  "kind": "ClusterRole",
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "metadata": {
+    "name": "node-reader"
+  },
+  "rules": [
+    {
+      "apiGroups": [
+        ""
+      ],
+      "resources": [
+        "nodes"
+      ],
+      "resourceNames": [
+        "my-node"
+      ],
+      "nonResourceURLs": [
+        "/healthz"
+      ],
+      "verbs": [
+        "get",
+        "watch",
+        "list"
+      ]
+    }
+  ]
+}

--- a/kubernetes-model/src/test/resources/valid-kubernetesClusterRoleBinding.json
+++ b/kubernetes-model/src/test/resources/valid-kubernetesClusterRoleBinding.json
@@ -1,0 +1,20 @@
+{
+  "kind": "ClusterRoleBinding",
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "metadata": {
+    "name": "read-nodes"
+  },
+  "subjects": [
+    {
+      "kind": "ServiceAccount",
+      "name": "node-reader",
+      "namespace": "default",
+      "apiGroup": "rbac.authorization.k8s.io"
+    }
+  ],
+  "roleRef": {
+    "kind": "ClusterRole",
+    "name": "node-reader",
+    "apiGroup": "rbac.authorization.k8s.io"
+  }
+}


### PR DESCRIPTION
This PR should add support for the ClusterRole and ClusterRoleBinding resources. 
* The `kube-schema.json` and the `kube-schema.json` were generated by the Go based generator. TBH I'm not sure I understand why it did some of the changes in `kube-schema.json`. They seem unrelated - does the generated file need to be somehow cleaned up afterwards?
* The tests are similar to the tests from #312 which added support for Role and RoleBinding.

Fixes #327 